### PR TITLE
Deprecate bitnami-shell from vulndb

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ $ docker run bitnami/postgresql cat /opt/bitnami/postgresql/.spdx-postgresql.spd
 
 ## Deprecation notes
 
+### 2023-08
+
+* Bitnami Shell
+
 ### 2023-07
 
 * Wavefront

--- a/config/components/bitnami-shell.json
+++ b/config/components/bitnami-shell.json
@@ -1,3 +1,4 @@
 {
-  "name": "bitnami-shell"
+  "name": "bitnami-shell",
+  "to-be-deprecated": "20230820"
 }


### PR DESCRIPTION
### Description of the change
This asset is deprecated in favor of [OS Shell](https://github.com/bitnami/containers/tree/main/bitnami/os-shell)