### PR TITLE
Replace json-schema with check-jsonschema

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -25,8 +25,8 @@ jobs:
         run: sudo apt-get install -y jq python3
       - name: Install markdownlint
         run: npm install -g markdownlint-cli@0.33.0
-      - name: Install jsonschema
-        run: python3 -m pip install jsonschema
+      - name: Install check-jsonschema
+        run: python3 -m pip install check-jsonschema
       - uses: actions/checkout@v3
         name: Checkout Repository
       - id: lint

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -19,6 +19,7 @@ elif [[ "$FORCE" -eq 1 ]] && [[ "${#files_to_check[@]}" -eq 0 ]]; then
 fi
 
 if [[ "${#files_to_check[@]}" -ne 0 ]]; then
+    echo "Will check ${#files_to_check[@]} files"
     for f in "${files_to_check[@]}"; do
         if [[ -f "$f" ]]; then
             # Run a different linter depending on file extension
@@ -38,7 +39,7 @@ if [[ "${#files_to_check[@]}" -ne 0 ]]; then
                     exit_code=$?
                 elif [[ "$f" =~ .*\/?data\/.* ]]; then
                     # Check CVE file against OSV schema
-                    output="$(jsonschema "${root_dir}/config/validation/schema.json" < "$f" 2>/dev/null)"
+                    check-jsonschema --verbose --schemafile "${root_dir}/config/validation/schema.json" "$f"
                     exit_code=$?
                 fi
                 if [[ $exit_code -ne 0 ]]; then


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

`json-schema` shows a deprecation warning in favour of `check-jsonschema`. This PR replaces one tool with the other.

```
root@99d04b456ae9:/vulndb# jsonschema "./config/validation/schema.json" < "./data/apache/BIT-2023-25690.json"; echo "exitCode: $?"
/opt/bitnami/python/bin/jsonschema:5: DeprecationWarning: The jsonschema CLI is deprecated and will be removed in a future version. Please use check-jsonschema instead, which can be installed from https://pypi.org/project/check-jsonschema/
  from jsonschema.cli import main
exitCode: 0
```

### Benefits

Remove internal dependency on deprecated tools.

### Possible drawbacks

Not expected.

### Additional information

Local test:

```
root@b17617f7a6c9:/vulndb# check-jsonschema --schemafile ./config/validation/schema.json ./data/apache/BIT-2023-27522.json; echo "exitCode: $?"
ok -- validation done
exitCode: 0

# Performs a bad substitution 'id' to '_id' field

root@b17617f7a6c9:/vulndb# check-jsonschema --schemafile ./config/validation/schema.json ./data/apache/BIT-2023-27522.json; echo "exitCode: $?"
Schema validation errors were encountered.
  data/apache/BIT-2023-27522.json::$: 'id' is a required property
  data/apache/BIT-2023-27522.json::$: Additional properties are not allowed ('_id' was unexpected)
exitCode: 1
```