### PR TITLE
fix: CPE information for NGINX Ingress Controller

### DIFF
--- a/config/components/nginx-ingress-controller.json
+++ b/config/components/nginx-ingress-controller.json
@@ -1,5 +1,5 @@
 {
   "name": "nginx-ingress-controller",
-  "cpeVendor": "f5",
-  "cpeProduct": "nginx_ingress_controller"
+  "cpeVendor": "kubernetes",
+  "cpeProduct": "ingress-nginx"
 }


### PR DESCRIPTION
### Description of the change

Update CPE information for NGINX Ingress Controller in order to point to the right product we ship.

### Benefits

Correct information is provided. No false positives.

### Possible drawbacks

None

### Applicable issues

NA

### Additional information

Our `bitnami/nginx-ingress-controller` [container](https://github.com/bitnami/containers/tree/main/bitnami/nginx-ingress-controller) is based on https://kubernetes.github.io/ingress-nginx/ and not on https://docs.nginx.com/nginx-ingress-controller/.

As it might be inferred, both are different products with different versioning (and hence, different CPE as well). You can check that using NVD for a vulnerability that affects K8s's NGINX-IC ([CVE-2022-4886](https://nvd.nist.gov/vuln/detail/CVE-2022-4886)) vs. one that affects F5's NGINX-IC (https://nvd.nist.gov/vuln/detail/CVE-2021-23055).
