### PR TITLE
Update Jenkins CPE to only capture LTS version

### DIFF
--- a/config/components/jenkins.json
+++ b/config/components/jenkins.json
@@ -1,3 +1,4 @@
 {
-  "name": "jenkins"
+  "name": "jenkins",
+  "cpeSoftwareEdition": "lts"
 }


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

[Jenkins](https://www.jenkins.io/download/) has 2 versions:
- LTS, also called stable
- Weekly

We only release the LTS version and as such our CPE should only refer to that version.
### Benefits

If a CVE is only present in the weekly version vulndb won't report a CVE our bitnami/jenkins release.

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
Jenkins' [CPE summary](https://nvd.nist.gov/products/cpe/detail/0F11B1A6-957A-45E5-8EEA-E10DC7B40C95)