### PR TITLE
[cilium-operator]: Configure cpeVendor & cpeProduct

### DIFF
--- a/config/components/cilium-operator.json
+++ b/config/components/cilium-operator.json
@@ -1,3 +1,5 @@
 {
-  "name": "cilium"
+  "name": "cilium-operator",
+  "cpeVendor": "cilium",
+  "cpeProduct": "cilium"
 }


### PR DESCRIPTION
### Description of the change

Follows up https://github.com/bitnami/vulndb/pull/441 configuring Cilium Operator to use `cilium` as _cpeVendor_ & _cpeProduct_.
