### PR TITLE
chore: Add Hubble Relay & related components to vulndb

### DIFF
--- a/config/components/grpc-health-probe.json
+++ b/config/components/grpc-health-probe.json
@@ -1,0 +1,3 @@
+{
+  "name": "grpc-health-probe"
+}

--- a/config/components/hubble-relay.json
+++ b/config/components/hubble-relay.json
@@ -1,0 +1,5 @@
+{
+  "name": "hubble-relay",
+  "cpeVendor": "cilium",
+  "cpeProduct": "cilium"
+}


### PR DESCRIPTION
### Description of the change

This PR adds Hubble Relay (part of [Cilium](https://cilium.io/)) and [grpc-health-probe](https://github.com/grpc-ecosystem/grpc-health-probe) to the vulnerability database.

Vendor and application would be `cilium` for Hubble Relay given it's a sub-component of Cilium.

There's no information about CVE for grpc-health-probe on National Vulnerability Database.

### Benefits

New components vulnerabilities to be reported in the vulndb.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A