### PR TITLE
chore: Deprecate Publify & Redash

### DIFF
--- a/config/components/publify.json
+++ b/config/components/publify.json
@@ -1,4 +1,5 @@
 {
   "name": "publify",
-  "cpeVendor": "publify_project"
+  "cpeVendor": "publify_project",
+  "to-be-deprecated": "20240627"
 }

--- a/config/components/redash.json
+++ b/config/components/redash.json
@@ -1,3 +1,4 @@
 {
-  "name": "redash"
+  "name": "redash",
+  "to-be-deprecated": "20240627"
 }


### PR DESCRIPTION
### Description of the change

This PR updates Publify & Redash configuration to mark them as "to-be-deprecated".

### Benefits

N/A

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A
