### PR TITLE
chore: Add Hubble UI components to vulndb

### DIFF
--- a/config/components/hubble-ui-backend.json
+++ b/config/components/hubble-ui-backend.json
@@ -1,0 +1,5 @@
+{
+  "name": "hubble-ui-backend",
+  "cpeVendor": "cilium",
+  "cpeProduct": "cilium"
+}

--- a/config/components/hubble-ui.json
+++ b/config/components/hubble-ui.json
@@ -1,0 +1,5 @@
+{
+  "name": "hubble-ui",
+  "cpeVendor": "cilium",
+  "cpeProduct": "cilium"
+}


### PR DESCRIPTION
### Description of the change

This PR adds Hubble UI (part of [Cilium](https://cilium.io/)) components to the vulnerability database.

Vendor and application would be `cilium` for Hubble UI & Hubble UI Backend given they're sub-components of Cilium.

### Benefits

New components vulnerabilities to be reported in the vulndb.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A