### PR TITLE
chore: Add new Cilium sub-components to vulndb

### DIFF
--- a/config/components/bpftool.json
+++ b/config/components/bpftool.json
@@ -1,0 +1,5 @@
+{
+  "name": "bpftool",
+  "cpeVendor": "libbpf_project",
+  "cpeProduct": "libbpf"
+}

--- a/config/components/llvm.json
+++ b/config/components/llvm.json
@@ -1,0 +1,5 @@
+{
+  "name": "llvm",
+  "cpeVendor": "llvm",
+  "cpeProduct": "clang"
+}


### PR DESCRIPTION
### Description of the change

This PR adds new Cilium sub-components (LLVM & bpftool) to the vulnerability database.

### Benefits

New components vulnerabilities to be reported in the vulndb.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A