### PR TITLE
chore: Add Cilium Proxy to vulndb

### DIFF
--- a/config/components/cilium-proxy.json
+++ b/config/components/cilium-proxy.json
@@ -1,0 +1,5 @@
+{
+  "name": "cilium-proxy",
+  "cpeVendor": "cilium",
+  "cpeProduct": "cilium"
+}


### PR DESCRIPTION
### Description of the change

This PR adds Cilium Proxy (part of [Cilium](https://cilium.io/)) to the vulnerability database.

Vendor and application would be `cilium` for Cilium Proxy given it's a sub-component of Cilium.

### Benefits

New components vulnerabilities to be reported in the vulndb.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A