### PR TITLE
[bitnami/miniforge] chore: :wrench: :wastebasket: Add to vulndb and deprecate miniconda

### DIFF
--- a/config/components/miniconda.json
+++ b/config/components/miniconda.json
@@ -1,5 +1,6 @@
 {
   "name": "miniconda",
   "cpeVendor": "conda",
-  "cpeProduct": "miniconda3"
+  "cpeProduct": "miniconda3",
+  "to-be-deprecated": "20240923"
 }

--- a/config/components/miniforge.json
+++ b/config/components/miniforge.json
@@ -1,0 +1,5 @@
+{
+  "name": "miniforge",
+  "cpeVendor": "conda",
+  "cpeProduct": "miniforge3"
+}


### PR DESCRIPTION
### Description of the change

This pull request adds the miniforge component to the vundb database. Miniforge is a minimal installer for Conda specific to conda-forge, which will enhance the functionality of our vundb database.

### Benefits

- Improves the package management capabilities of the vundb database

### Possible drawbacks

- Did not find a CVE entry for miniforge, so we’re inferring the same as miniconda

### Applicable issues

- fixes #1663

### Additional information

The integration of miniforge into vundb has been tested locally and appears to work as expected. However, extensive testing in various environments is recommended before merging.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [[semver](http://semver.org/)](http://semver.org/).
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [[readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/vundb] Add miniforge component
- [X] All commits signed off and in agreement of [[Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)