### PR TITLE
[bitnami/supabase-*] Deprecate Supabase Postgres libraries

### DIFF
--- a/config/components/groonga.json
+++ b/config/components/groonga.json
@@ -1,4 +1,5 @@
 {
   "name": "groonga",
-  "cpeProduct": "groonga-httpd"
+  "cpeProduct": "groonga-httpd",
+  "to-be-deprecated": "20240929"
 }

--- a/config/components/hypopg.json
+++ b/config/components/hypopg.json
@@ -1,3 +1,4 @@
 {
-  "name": "hypopg"
+  "name": "hypopg",
+  "to-be-deprecated": "20240929"
 }

--- a/config/components/pg-safeupdate.json
+++ b/config/components/pg-safeupdate.json
@@ -1,3 +1,4 @@
 {
-  "name": "pg-safeupdate"
+  "name": "pg-safeupdate",
+  "to-be-deprecated": "20240929"
 }

--- a/config/components/pg_cron.json
+++ b/config/components/pg_cron.json
@@ -1,3 +1,4 @@
 {
-  "name": "pg_cron"
+  "name": "pg_cron",
+  "to-be-deprecated": "20240929"
 }

--- a/config/components/pg_hashids.json
+++ b/config/components/pg_hashids.json
@@ -1,3 +1,4 @@
 {
-  "name": "pg_hashids"
+  "name": "pg_hashids",
+  "to-be-deprecated": "20240929"
 }

--- a/config/components/pg_jsonschema.json
+++ b/config/components/pg_jsonschema.json
@@ -1,3 +1,4 @@
 {
-  "name": "pg_jsonschema"
+  "name": "pg_jsonschema",
+  "to-be-deprecated": "20240929"
 }

--- a/config/components/pg_net.json
+++ b/config/components/pg_net.json
@@ -1,3 +1,4 @@
 {
-  "name": "pg_net"
+  "name": "pg_net",
+  "to-be-deprecated": "20240929"
 }

--- a/config/components/pg_plan_filter.json
+++ b/config/components/pg_plan_filter.json
@@ -1,3 +1,4 @@
 {
-  "name": "pg_plan_filter"
+  "name": "pg_plan_filter",
+  "to-be-deprecated": "20240929"
 }

--- a/config/components/pg_repack.json
+++ b/config/components/pg_repack.json
@@ -1,3 +1,4 @@
 {
-  "name": "pg_repack"
+  "name": "pg_repack",
+  "to-be-deprecated": "20240929"
 }

--- a/config/components/pg_stat_monitor.json
+++ b/config/components/pg_stat_monitor.json
@@ -1,3 +1,4 @@
 {
-  "name": "pg_stat_monitor"
+  "name": "pg_stat_monitor",
+  "to-be-deprecated": "20240929"
 }

--- a/config/components/pgjwt.json
+++ b/config/components/pgjwt.json
@@ -1,3 +1,4 @@
 {
-  "name": "pgjwt"
+  "name": "pgjwt",
+  "to-be-deprecated": "20240929"
 }

--- a/config/components/pgroonga.json
+++ b/config/components/pgroonga.json
@@ -1,3 +1,4 @@
 {
-  "name": "pgroonga"
+  "name": "pgroonga",
+  "to-be-deprecated": "20240929"
 }

--- a/config/components/pgrouting.json
+++ b/config/components/pgrouting.json
@@ -1,3 +1,4 @@
 {
-  "name": "pgrouting"
+  "name": "pgrouting",
+  "to-be-deprecated": "20240929"
 }

--- a/config/components/pgsodium.json
+++ b/config/components/pgsodium.json
@@ -1,3 +1,4 @@
 {
-  "name": "pgsodium"
+  "name": "pgsodium",
+  "to-be-deprecated": "20240929"
 }

--- a/config/components/pgsql-http.json
+++ b/config/components/pgsql-http.json
@@ -1,3 +1,4 @@
 {
-  "name": "pgsql-http"
+  "name": "pgsql-http",
+  "to-be-deprecated": "20240929"
 }

--- a/config/components/pgtap.json
+++ b/config/components/pgtap.json
@@ -1,3 +1,4 @@
 {
-  "name": "pgtap"
+  "name": "pgtap",
+  "to-be-deprecated": "20240929"
 }

--- a/config/components/pgvector.json
+++ b/config/components/pgvector.json
@@ -1,3 +1,4 @@
 {
-  "name": "pgvector"
+  "name": "pgvector",
+  "to-be-deprecated": "20240929"
 }

--- a/config/components/plpgsql_check.json
+++ b/config/components/plpgsql_check.json
@@ -1,3 +1,4 @@
 {
-  "name": "plpgsql_check"
+  "name": "plpgsql_check",
+  "to-be-deprecated": "20240929"
 }

--- a/config/components/plv8.json
+++ b/config/components/plv8.json
@@ -1,3 +1,4 @@
 {
-  "name": "plv8"
+  "name": "plv8",
+  "to-be-deprecated": "20240929"
 }

--- a/config/components/timescaledb.json
+++ b/config/components/timescaledb.json
@@ -1,4 +1,5 @@
 {
   "name": "timescaledb",
-  "cpeVendor": "timescale"
+  "cpeVendor": "timescale",
+  "to-be-deprecated": "20240929"
 }


### PR DESCRIPTION
### Description of the change

Follows up https://github.com/bitnami/vulndb/pull/584 marking as deprecated every library that was exclusively used to compile Supabase Postgres.