### PR TITLE
ci: fix check-jsonschema installation

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -22,11 +22,11 @@ jobs:
       allow_auto_merge: ${{ steps.lint.outputs.allow_auto_merge }}
     steps:
       - name: Install system deps
-        run: sudo apt-get install -y jq python3
+        run: sudo apt-get install -y jq python3 pipx
       - name: Install markdownlint
         run: npm install -g markdownlint-cli@0.33.0
       - name: Install check-jsonschema
-        run: python3 -m pip install check-jsonschema
+        run: pipx install check-jsonschema
       - uses: actions/checkout@v3
         name: Checkout Repository
       - id: lint


### PR DESCRIPTION
### Description of the change

This PR fixes `check-jsonschema` installation currently failing with the error below:

```
error: externally-managed-environment
× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.
note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP [6](https://github.com/bitnami/vulndb/actions/runs/11353206466/job/31599177113#step:4:7)68 for the detailed specification.
```

### Benefits

CI works as expected.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A
