### PR TITLE
Fix alertmanager component

### DIFF
--- a/config/components/alertmanager.json
+++ b/config/components/alertmanager.json
@@ -1,3 +1,4 @@
 {
-  "name": "alertmanager"
+  "name": "alertmanager",
+  "cpeVendor": "prometheus"
 }


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Adds the correct cpe vendor for Alertmanager.  NVD has vendor as `prometheus`.

### Benefits

Correct tracking of alertmanager vulnerabilities.

### Possible drawbacks

None noted

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #658

### Additional information
I do not know how the spdx file inside the container is generated.  If not via this config file, that should get changed as well as it curently shows `cpe:2.3:*:alertmanager:alertmanager:0.27.0:*:*:*:*:*:*:*`.

I assume the process to generate vulnerability records is not public, so unsure how actual alertmanager records will get added here.