### PR TITLE
[actions] Pin GitHub actions with commit hashes

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     name: 'Upload modified files to s3'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 2 # to be able to obtain files changed in the latest commit
       - name: Install and configure s3cmd
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: Notify in Slack channel
         if: ${{ needs.s3-upload.result != 'success' }}
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           channel-id: ${{ secrets.CD_SLACK_CHANNEL_ID }}
           payload: |

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -27,7 +27,7 @@ jobs:
         run: npm install -g markdownlint-cli@0.33.0
       - name: Install check-jsonschema
         run: pipx install check-jsonschema
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         name: Checkout Repository
       - id: lint
         name: Lint modified files
@@ -65,7 +65,7 @@ jobs:
         if: |
           needs.lint.result == 'success' &&
           needs.lint.outputs.allow_auto_merge == 'true'
-        uses: hmarr/auto-approve-action@v4.0.0
+        uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
         with:
           pull-request-number: ${{ github.event.number }}
       - name: Merge
@@ -73,7 +73,7 @@ jobs:
         if: |
           needs.lint.result == 'success' &&
           needs.lint.outputs.allow_auto_merge == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           result-encoding: string
           retries: 3
@@ -89,7 +89,7 @@ jobs:
       # post a comment on the PR and assign a maintainer agent to review it
       - name: Manual review required
         if: ${{ always() && (needs.lint.result != 'success' || steps.merge.outcome != 'success' ) }}
-        uses: peter-evans/create-or-update-comment@v4.0.0
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           issue-number: ${{ github.event.number }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -98,7 +98,7 @@ jobs:
             Please check the related [action_run#${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more information and the changes in the final files (too many files updated at the same time?).
       - name: Assign to a person to work on it
         if: ${{ always() && (needs.lint.result != 'success' || steps.merge.outcome != 'success' ) }}
-        uses: pozil/auto-assign-issue@v2.1.2
+        uses: pozil/auto-assign-issue@c015a6a3f410f12f58255c3d085fd774312f7a2f # v2.1.2
         with:
           numOfAssignee: 1
           teams: ${{ secrets.SUPPORT_TEAM }}

--- a/.github/workflows/pr-reviews.yml
+++ b/.github/workflows/pr-reviews.yml
@@ -11,7 +11,7 @@ on:
       - submitted
       - dismissed
 permissions: {}
-# Avoid concurrency over the same issue
+# Avoid concurrency over the same issue
 concurrency:
   group: card-movement-${{ github.event.pull_request.number }}
 jobs:
@@ -23,7 +23,7 @@ jobs:
           echo "::notice:: Comment on PR #${{ github.event.pull_request.number }}"
           jq -n --arg issue '${{ github.event.pull_request.number }}' --arg state '${{ github.event.review != null && github.event.review.state || '' }}' '{"issue": {"number": $issue }, "review": { "state": $state }}' > pull_request_info.json
       - name: Upload the PR info
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: pull_request_info.json
           path: ./pull_request_info.json


### PR DESCRIPTION
### Description of the change

Pinning an action to a full length commit SHA is currently the only way to use a non-immutable action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload

### Benefits

Clears security concerns related to GitHub Actions.

### Possible drawbacks

Not expected.

### Applicable issues

* https://github.com/bitnami/vulndb/security/code-scanning/6
* https://github.com/bitnami/vulndb/security/code-scanning/7
* https://github.com/bitnami/vulndb/security/code-scanning/8
* https://github.com/bitnami/vulndb/security/code-scanning/9