### PR TITLE
[bitnami/vulndb] chore(workflows): Avoid running scheduled workflows in forked repositories

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -13,6 +13,7 @@ jobs:
   s3-upload:
     runs-on: ubuntu-latest
     name: 'Upload modified files to s3'
+    if: ${{ github.repository_owner == 'bitnami' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
### Description of the change

Check repository ownership to avoid running scheduled or CD workflows in forked repositories.

### Benefits

Skip unnecessary executions and failures in forks.

### Possible drawbacks

None

### Checklist

- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
