### PR TITLE
[bitnami/cadvisor] chore: :wrench: Add to vulndb

### DIFF
--- a/config/components/cadvisor.json
+++ b/config/components/cadvisor.json
@@ -1,0 +1,5 @@
+{
+    "name": "cadvisor",
+    "cpeVendor": "google",
+    "cpeProduct": "cadvisor"
+  }


### PR DESCRIPTION
### Description of the change

This PR adds the definition of cadvisor. Using the GH Repo as the reference, we assume that the vendor is Google.