### PR TITLE
Update fixed versions for CVE-2025-21605

### DIFF
--- a/data/redis/BIT-redis-2025-21605.json
+++ b/data/redis/BIT-redis-2025-21605.json
@@ -26,6 +26,28 @@
               "introduced": "2.6.0"
             },
             {
+              "fixed": "6.2.18"
+            }
+          ]
+        },
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "7.2.0"
+            },
+            {
+              "fixed": "7.2.8"
+            }
+          ]
+        },
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "7.4.0"
+            },
+            {
               "fixed": "7.4.3"
             }
           ]


### PR DESCRIPTION
### Description of the change

Information for CVE-2025-21605 was wrong. Updating info from official security advisory

https://redis.io/blog/security-advisory-cve-2025-21605/