### PR TITLE
chore: influxdb-core as alias for influxdb

### DIFF
--- a/config/components/influxdb-core.json
+++ b/config/components/influxdb-core.json
@@ -1,0 +1,4 @@
+{
+  "name": "influxdb",
+  "cpeVendor": "influxdata"
+}


### PR DESCRIPTION
### Description of the change

This PR adds the configuration for `influxdb-core`, an alias for `influxdb`.