### PR TITLE
Restore kaniko support

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ $ docker run bitnami/postgresql cat /opt/bitnami/postgresql/.spdx-postgresql.spd
 
 ### 2025-06
 
-- Kaniko
 - KES
 
 ### 2025-05

--- a/config/components/kaniko.json
+++ b/config/components/kaniko.json
@@ -1,4 +1,3 @@
 {
-  "name": "kaniko",
-  "to-be-deprecated": "20250716"
+  "name": "kaniko"
 }


### PR DESCRIPTION
We'll restore the deprecated Kaniko using a new [maintained fork](https://github.com/chainguard-dev/kaniko).
Partially revert https://github.com/bitnami/vulndb/pull/962