### PR TITLE
Deprecate Matomo, Subversion and SuiteCRM

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ $ docker run bitnami/postgresql cat /opt/bitnami/postgresql/.spdx-postgresql.spd
 ### 2025-08
 
 - Dolibarr
+- Matomo
+- Subversion
+- SuiteCRM
 
 ### 2025-06
 

--- a/config/components/matomo.json
+++ b/config/components/matomo.json
@@ -1,4 +1,5 @@
 {
   "name": "matomo",
-  "cpeProduct": "integration"
+  "cpeProduct": "integration",
+  "to-be-deprecated": "20250904"
 }

--- a/config/components/subversion.json
+++ b/config/components/subversion.json
@@ -1,4 +1,5 @@
 {
   "name": "subversion",
-  "cpeVendor": "apache"
+  "cpeVendor": "apache",
+  "to-be-deprecated": "20250904"
 }

--- a/config/components/suitecrm.json
+++ b/config/components/suitecrm.json
@@ -1,4 +1,5 @@
 {
   "name": "suitecrm",
-  "cpeVendor": "salesagility"
+  "cpeVendor": "salesagility",
+  "to-be-deprecated": "20250904"
 }


### PR DESCRIPTION
### Description of the change

After reviewing the usage of VMs and Cloud Images, we identified these ones as the least used in terms of launches