### PR TITLE
chore: rename nss_wrapper

### DIFF
--- a/config/components/nss-wrapper.json
+++ b/config/components/nss-wrapper.json
@@ -1,0 +1,4 @@
+{
+  "name": "nss-wrapper",
+  "cpeProduct": "nss_wrapper"
+}

--- a/config/components/nss_wrapper.json
+++ b/config/components/nss_wrapper.json
@@ -1,3 +1,0 @@
-{
-  "name": "nss_wrapper"
-}


### PR DESCRIPTION
### Description of the change

This PR renames `nss_wrapper` to `nss-wrapper` to comply with our naming standards.