### PR TITLE
chore: add Flux Source Watcher to vulndb

### DIFF
--- a/config/components/fluxcd-source-watcher.json
+++ b/config/components/fluxcd-source-watcher.json
@@ -1,0 +1,3 @@
+{
+  "name": "fluxcd-source-watcher"
+}


### PR DESCRIPTION
### Description of the change

This PR adds [Flux Source Watcher](https://github.com/fluxcd/source-watcher) components to vulndb
