### PR TITLE
[bitnami/local-path-provisioner] chore: :wrench: Add to vulndb

### DIFF
--- a/config/components/local-path-provisioner.json
+++ b/config/components/local-path-provisioner.json
@@ -1,0 +1,4 @@
+{
+    "name": "local-path-provisioner",
+    "cpeVendor": "rancher"
+}


### PR DESCRIPTION
This PR adds the definition for local-path-provisioner. As the new owner is rancher we changed the CPEVendor
