### PR TITLE
Deprecate Apisix Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ $ docker run bitnami/postgresql cat /opt/bitnami/postgresql/.spdx-postgresql.spd
 
 ## Deprecation notes
 
+### 2025-10
+
+- Apisix Dashboard
+
 ### 2025-09
 
 - Gonit

--- a/config/components/apisix-dashboard.json
+++ b/config/components/apisix-dashboard.json
@@ -1,4 +1,5 @@
 {
   "name": "apisix_dashboard",
-  "cpeVendor": "apache"
+  "cpeVendor": "apache",
+  "to-be-deprecated": "20251130"
 }


### PR DESCRIPTION
The dashboard is now integrated in Apisix itself, see https://github.com/apache/apisix-dashboard/releases/tag/notice