### PR TITLE
Deprecate Keycloak Metrics SPI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ $ docker run bitnami/postgresql cat /opt/bitnami/postgresql/.spdx-postgresql.spd
 
 ## Deprecation notes
 
+### 2025-11
+
+- Keycloak Metrics SPI
+
 ### 2025-10
 
 - Apisix Dashboard

--- a/config/components/keycloak-metrics-spi.json
+++ b/config/components/keycloak-metrics-spi.json
@@ -1,3 +1,4 @@
 {
-  "name": "keycloak-metrics-spi"
+  "name": "keycloak-metrics-spi",
+  "to-be-deprecated": "20251203"
 }


### PR DESCRIPTION
We're not shipping this Keycloak extension anymore with the container image, hence we can remove it.