### PR TITLE
Deprecate Bower and Express Generator

### DIFF
--- a/config/components/bower.json
+++ b/config/components/bower.json
@@ -1,3 +1,4 @@
 {
-  "name": "bower"
+  "name": "bower",
+  "to-be-deprecated": "2025-12-11"
 }

--- a/config/components/express-generator.json
+++ b/config/components/express-generator.json
@@ -1,3 +1,4 @@
 {
-  "name": "express-generator"
+  "name": "express-generator",
+  "to-be-deprecated": "2025-12-11"
 }


### PR DESCRIPTION
### Description of the change

Deprecating these components as they have not released a new version during the last 4+ years.