### PR TITLE
[TNZ-67896] Deprecate sequelize-cli

### DIFF
--- a/config/components/sequelize-cli.json
+++ b/config/components/sequelize-cli.json
@@ -1,3 +1,4 @@
 {
-  "name": "sequelize-cli"
+  "name": "sequelize-cli",
+  "to-be-deprecated": "2025-12-13"
 }


### PR DESCRIPTION
### Description of the change

Deprecate sequelize-cli component after removing support for Express container