### PR TITLE
[bitnami/mcp-grafana] chore: :wrench: Add to vulndb

### DIFF
--- a/config/components/mcp-grafana.json
+++ b/config/components/mcp-grafana.json
@@ -1,0 +1,4 @@
+{
+    "name": "mcp-grafana",
+    "cpeVendor": "grafana"
+}


### PR DESCRIPTION
This PR adds an entry for mcp-grafana, though there no known CVEs at the moment.