### PR TITLE
Deprecate elasticsearch-plugin-repository-s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ $ docker run bitnami/postgresql cat /opt/bitnami/postgresql/.spdx-postgresql.spd
 
 ## Deprecation notes
 
+### 2026-01
+
+- elasticsearch-plugin-repository-s3
+
 ### 2025-12
 
 - LimeSurvey

--- a/config/components/elasticsearch-plugin-repository-s3.json
+++ b/config/components/elasticsearch-plugin-repository-s3.json
@@ -1,3 +1,4 @@
 {
-  "name": "elasticsearch-plugin-repository-s3"
+  "name": "elasticsearch-plugin-repository-s3",
+  "to-be-deprecated": "20260214"
 }


### PR DESCRIPTION
This plugin was only needed for Elasticsearch 7, which is deprecated now