### PR TITLE
[bitnami/mcp-mongodb] chore: :wrench: Add to vulndb

### DIFF
--- a/config/components/mcp-mongodb.json
+++ b/config/components/mcp-mongodb.json
@@ -1,0 +1,5 @@
+{
+    "name": "mcp-mongodb",
+    "cpeVendor": "mongodb",
+    "cpeProduct": "mongodb-mcp-server"
+}


### PR DESCRIPTION
This PR adds the definition of mcp-mongodb to vulndb. We have no CVEs but we use the product name from upstream