### PR TITLE
[bitnami/mcp-clickhouse] chore: :wrench: Add to vulndb

### DIFF
--- a/config/components/mcp-clickhouse.json
+++ b/config/components/mcp-clickhouse.json
@@ -1,0 +1,4 @@
+{
+    "name": "mcp-clickhouse",
+    "cpeVendor": "clickhouse"
+}


### PR DESCRIPTION
This PR adds mcp-clickhouse to vulndb. Using clickhouse as the cpevendor based on https://nvd.nist.gov/vuln/detail/CVE-2024-22412