### PR TITLE
chore: add Crossplane to vulndb

### DIFF
--- a/config/components/crossplane.json
+++ b/config/components/crossplane.json
@@ -1,0 +1,4 @@
+{
+    "name": "crossplane",
+    "cpeVendor": "cncf"
+}


### PR DESCRIPTION
### Description of the change

This PR adds Crossplane to the Vulnerability Database. NVD data:

- https://nvd.nist.gov/products/cpe/search/results?namingFormat=2.3&keyword=crossplane
