### PR TITLE
Deprecate bndiagnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ $ docker run bitnami/postgresql cat /opt/bitnami/postgresql/.spdx-postgresql.spd
 ### 2026-01
 
 - elasticsearch-plugin-repository-s3
+- bndiagnostic
 
 ### 2025-12
 

--- a/config/components/bndiagnostic.json
+++ b/config/components/bndiagnostic.json
@@ -1,3 +1,4 @@
 {
-  "name": "bndiagnostic"
+  "name": "bndiagnostic",
+  "to-be-deprecated": "20260226"
 }


### PR DESCRIPTION
After archiving the GH repo at https://github.com/bitnami/bndiagnostic/commit/82070e3eb37f069c4f6c4e94f9710622bb6d6ec6 and updating the support cases template at https://github.com/bitnami/vms/commit/4e66522fbcdaf4ba40a7e59d41154c5b224ac503, we can continue with this deprecation step