### PR TITLE
[bitnami/semantic-release] chore: :wrench: Add to vulndb

### DIFF
--- a/config/components/semantic-release.json
+++ b/config/components/semantic-release.json
@@ -1,0 +1,3 @@
+{
+    "name": "semantic-release"
+}


### PR DESCRIPTION
This PR adds the entry for semantic-release. We do not have CVE information so we use the package name