### PR TITLE
[TNZ-92745] chore(authentik): Add Authentik to vulndb

### DIFF
--- a/config/components/authentik.json
+++ b/config/components/authentik.json
@@ -1,0 +1,3 @@
+{
+  "name": "authentik"
+}

--- a/config/components/authentik.json
+++ b/config/components/authentik.json
@@ -1,3 +1,5 @@
 {
-  "name": "authentik"
+  "name": "authentik",
+  "cpeVendor": "goauthentik",
+  "cpeProduct": "authentik"
 }


### PR DESCRIPTION
## Summary
Registers **authentik** in vulndb and sets `cpeVendor` to **goauthentik** so CVE matching aligns with NVD (`cpe:2.3:a:goauthentik:authentik:*:*:*:*:*:*:*:*`).

## Ticket
https://vmw-jira.broadcom.net/browse/TNZ-92745

ai-assisted=yes