### PR TITLE
Deprecate aws-java-sdk-bundle

### DIFF
--- a/config/components/aws-java-sdk-bundle.json
+++ b/config/components/aws-java-sdk-bundle.json
@@ -1,3 +1,4 @@
 {
-  "name": "aws-java-sdk-bundle"
+  "name": "aws-java-sdk-bundle",
+  "to-be-deprecated": "20260514"
 }


### PR DESCRIPTION
This product is being deprecated after Spark 3.5 deprecation