### PR TITLE
Deprecate attu

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,11 @@ $ docker run bitnami/postgresql cat /opt/bitnami/postgresql/.spdx-postgresql.spd
 
 ## Deprecation notes
 
+### 2026-04
+
+- Attu
+- aws-java-sdk-bundle
+
 ### 2026-02
 
 - Rails

--- a/config/components/attu.json
+++ b/config/components/attu.json
@@ -1,3 +1,4 @@
 {
-  "name": "attu"
+  "name": "attu",
+  "to-be-deprecated": "20260515"
 }


### PR DESCRIPTION
This product is deprecated because it is not open-source from a specific version onwards: https://github.com/zilliztech/attu/blob/main/LICENSE_PROPRIETARY.txt