### PR TITLE
Deprecate nginx-ingress-controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ $ docker run bitnami/postgresql cat /opt/bitnami/postgresql/.spdx-postgresql.spd
 
 - Attu
 - aws-java-sdk-bundle
+- NGINX Ingress Controller
 
 ### 2026-02
 

--- a/config/components/nginx-ingress-controller.json
+++ b/config/components/nginx-ingress-controller.json
@@ -1,5 +1,6 @@
 {
   "name": "nginx-ingress-controller",
   "cpeVendor": "kubernetes",
-  "cpeProduct": "ingress-nginx"
+  "cpeProduct": "ingress-nginx",
+  "to-be-deprecated": "20260520"
 }


### PR DESCRIPTION
This product is deprecated by the upstream; see https://github.com/kubernetes/ingress-NGINX?tab=readme-ov-file#retiring