### PR TITLE
[bitnami/opensearch-k8s-operator] feat: Add OpenSearch Kubernetes Operator to VulnDB

### DIFF
--- a/config/components/opensearch-operator.json
+++ b/config/components/opensearch-operator.json
@@ -1,0 +1,3 @@
+{
+    "name": "opensearch-k8s-operator"
+  }


### PR DESCRIPTION
### Description of the change

This PR adds the OpenSearch Kubernetes Operator to VulnDB.

Currently, there are no CPE records at https://nvd.nist.gov/products/cpe/search