### PR TITLE
[bitnami/k8ssandra] Add cass and k8ssandra components to vulndb

### DIFF
--- a/config/components/cass-cassandra.json
+++ b/config/components/cass-cassandra.json
@@ -1,0 +1,3 @@
+{
+  "name": "cass-cassandra"
+}

--- a/config/components/cass-config-builder.json
+++ b/config/components/cass-config-builder.json
@@ -1,0 +1,3 @@
+{
+  "name": "cass-config-builder"
+}

--- a/config/components/cass-management-api.json
+++ b/config/components/cass-management-api.json
@@ -1,0 +1,3 @@
+{
+  "name": "cass-management-api"
+}

--- a/config/components/cass-operator.json
+++ b/config/components/cass-operator.json
@@ -1,0 +1,3 @@
+{
+  "name": "cass-operator"
+}

--- a/config/components/cass-system-logger.json
+++ b/config/components/cass-system-logger.json
@@ -1,0 +1,3 @@
+{
+  "name": "cass-system-logger"
+}

--- a/config/components/k8ssandra-client.json
+++ b/config/components/k8ssandra-client.json
@@ -1,0 +1,3 @@
+{
+  "name": "k8ssandra-client"
+}

--- a/config/components/k8ssandra-medusa.json
+++ b/config/components/k8ssandra-medusa.json
@@ -1,0 +1,3 @@
+{
+  "name": "k8ssandra-medusa"
+}

--- a/config/components/k8ssandra-operator.json
+++ b/config/components/k8ssandra-operator.json
@@ -1,0 +1,3 @@
+{
+  "name": "k8ssandra-operator"
+}

--- a/config/components/k8ssandra-reaper.json
+++ b/config/components/k8ssandra-reaper.json
@@ -1,0 +1,3 @@
+{
+  "name": "k8ssandra-reaper"
+}

--- a/config/components/k8ssandra-stargate.json
+++ b/config/components/k8ssandra-stargate.json
@@ -1,0 +1,3 @@
+{
+  "name": "k8ssandra-stargate"
+}


### PR DESCRIPTION
## Summary
Adds vulndb component entries for the 9 new k8ssandra/cass catalog assets:
- `cass-cassandra` (management-api + Cassandra)
- `cass-config-builder` (datastax/cass-config-builder)
- `cass-operator` (k8ssandra/cass-operator)
- `cass-system-logger` (vectordotdev/vector)
- `k8ssandra-client` (k8ssandra/k8ssandra-client)
- `k8ssandra-medusa` (thelastpickle/cassandra-medusa)
- `k8ssandra-operator` (k8ssandra/k8ssandra-operator)
- `k8ssandra-reaper` (thelastpickle/cassandra-reaper)
- `k8ssandra-stargate` (stargate/stargate)

No NVD CPE records found for any of these assets, so all entries use the minimal `{"name": ...}` form.

ai-assisted=yes