### PR TITLE
[TNZ-103725] Deprecate bncert

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ $ docker run bitnami/postgresql cat /opt/bitnami/postgresql/.spdx-postgresql.spd
 
 ## Deprecation notes
 
+### 2026-05
+
+- bncert
+
 ### 2026-04
 
 - Attu

--- a/config/components/bncert.json
+++ b/config/components/bncert.json
@@ -1,3 +1,4 @@
 {
-  "name": "bncert"
+  "name": "bncert",
+  "to-be-deprecated": "20260620"
 }


### PR DESCRIPTION
bncert was deprecated, see https://github.com/bitnami/bncert/commit/c0702e37ede42075c8ae9ae8fdc0390c64820341