### PR TITLE
[bitnami/argo-rollouts] Add argo-rollouts and kubectl-argo-rollouts to vulndb

### DIFF
--- a/config/components/argo-rollouts.json
+++ b/config/components/argo-rollouts.json
@@ -1,0 +1,3 @@
+{
+  "name": "argo-rollouts"
+}

--- a/config/components/kubectl-argo-rollouts.json
+++ b/config/components/kubectl-argo-rollouts.json
@@ -1,0 +1,3 @@
+{
+  "name": "kubectl-argo-rollouts"
+}


### PR DESCRIPTION
## Summary

- Add `config/components/argo-rollouts.json` — register argo-rollouts controller container
- Add `config/components/kubectl-argo-rollouts.json` — register kubectl-argo-rollouts plugin/dashboard container

## Jira

[TNZ-98356](https://vmw-jira.broadcom.net/browse/TNZ-98356)