### PR TITLE
[bitnami/victoriametrics-vmbackup] feat: Add vulndb entries for vmbackup and vmrestore

### DIFF
--- a/config/components/victoriametrics-vmbackup.json
+++ b/config/components/victoriametrics-vmbackup.json
@@ -1,0 +1,5 @@
+{
+  "name": "victoriametrics-vmbackup",
+  "cpeVendor": "victoriametrics",
+  "cpeProduct": "victoriametrics"
+}

--- a/config/components/victoriametrics-vmrestore.json
+++ b/config/components/victoriametrics-vmrestore.json
@@ -1,0 +1,5 @@
+{
+  "name": "victoriametrics-vmrestore",
+  "cpeVendor": "victoriametrics",
+  "cpeProduct": "victoriametrics"
+}


### PR DESCRIPTION
## Summary

- Add `config/components/victoriametrics-vmbackup.json`
- Add `config/components/victoriametrics-vmrestore.json`

Both use `cpeVendor: victoriametrics` / `cpeProduct: victoriametrics` following the existing component pattern.

## Related

- Jira: [TNZ-118467](https://vmw-jira.broadcom.net/browse/TNZ-118467)

ai-assisted=yes