### PR TITLE
[bitnami/distribution] chore: Add to vulndb

### DIFF
--- a/config/components/distribution.json
+++ b/config/components/distribution.json
@@ -1,0 +1,3 @@
+{
+  "name": "distribution"
+}


### PR DESCRIPTION
Register the `distribution` component in the vulnerability database.

Ref: [TNZ-122380](https://vmw-jira.broadcom.net/browse/TNZ-122380)