### PR TITLE
[bitnami/kong-operator] Add to vulndb

### DIFF
--- a/config/components/kong-operator.json
+++ b/config/components/kong-operator.json
@@ -1,0 +1,3 @@
+{
+  "name": "kong-operator"
+}


### PR DESCRIPTION
## Summary

Adds `config/components/kong-operator.json`, registering the `kong-operator` asset for vulnerability scanning in vulndb. This mirrors the existing `reloader` registration (`config/components/reloader.json`), which uses the same minimal `{"name": "<component>"}` structure.

Part of the parallel TNZ-124370 onboarding sequence for the new "kong-operator" Bitnami product (a Kubernetes operator for Kong Gateway, comparable in container shape to reloader).

ai-assisted=yes