### PR TITLE
[TNZ-126019] Add tcp_wrappers to vulndb

### DIFF
--- a/config/components/tcp_wrappers.json
+++ b/config/components/tcp_wrappers.json
@@ -1,0 +1,3 @@
+{
+  "name": "tcp_wrappers"
+}


### PR DESCRIPTION
## Summary
- Add vulndb entry for `tcp_wrappers` component to enable vulnerability tracking.

Ref: [TNZ-126019](https://vmw-jira.broadcom.net/browse/TNZ-126019)