### PR TITLE
[bitnami/neo4j-enterprise] Add neo4j-enterprise and neo4j-enterprise-studio

### DIFF
--- a/config/components/neo4j-enterprise-studio.json
+++ b/config/components/neo4j-enterprise-studio.json
@@ -1,0 +1,3 @@
+{
+  "name": "neo4j-enterprise-studio"
+}

--- a/config/components/neo4j-enterprise.json
+++ b/config/components/neo4j-enterprise.json
@@ -1,0 +1,6 @@
+{
+  "name": "neo4j-enterprise",
+  "cpeVendor": "neo4j",
+  "cpeProduct": "neo4j",
+  "cpeTargetSoftware": "enterprise"
+}


### PR DESCRIPTION
## Summary
- Both components were missed during their respective onboardings (neo4j-enterprise, neo4j-enterprise-studio).
- `neo4j-enterprise`: overrides `cpeVendor`/`cpeProduct` to `neo4j`/`neo4j`, since Enterprise Edition CVEs are filed under the same base CPE as the community edition, just with an `enterprise` target_sw qualifier (`cpe:2.3:a:neo4j:neo4j:*:*:*:*:enterprise:*:*:*` on NVD).
- `neo4j-enterprise-studio`: name only - no CPE records exist for it on NVD yet.

## Test plan
- [x] `scripts/lint.sh` passes for both new files