### PR TITLE
[bitnami/csi-addons-controller] Add csi-addons-controller to vulndb

### DIFF
--- a/config/components/csi-addons-controller.json
+++ b/config/components/csi-addons-controller.json
@@ -1,0 +1,3 @@
+{
+  "name": "csi-addons-controller"
+}


### PR DESCRIPTION
## Summary
- Add `config/components/csi-addons-controller.json` for the CSI-Addons Controller container (part of https://vmw-jira.broadcom.net/browse/TNZ-144862 container-only onboarding).
- No CPE override needed: NVD has no distinct vendor/product string for `csi-addons`, consistent with sibling CSI sidecar entries (`csi-external-attacher`, `ceph-csi-operator`, etc.) which are also name-only.

ai-assisted=yes